### PR TITLE
Subtomogram phantom protocol

### DIFF
--- a/xmipptomo/protocols.conf
+++ b/xmipptomo/protocols.conf
@@ -4,6 +4,7 @@ Tomography = [
 	{"tag": "section", "text": "Movies/Micrographs", "children": []},
 	{"tag": "section", "text": "Reconstruction", "children": []},
     {"tag": "section", "text": "Particles", "children": [
+        {"tag": "protocol", "value": "XmippProtPhantomSubtomo", "text": "default"},
 		{"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
             {"tag": "protocol", "value": "XmippProtConnectedComponents", "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtRoiIJ",   "text": "default"},
@@ -17,7 +18,6 @@ Tomography = [
         {"tag": "protocol", "value": "XmippProtApplyTransformSubtomo", "text": "default"},
         {"tag": "protocol", "value": "XmippProtUndoAlignSubtomo", "text": "default"},
         {"tag": "protocol", "value": "XmippProtSubtomoMapBack", "text": "default"},
-        {"tag": "protocol", "value": "XmippProtPhantomSubtomo", "text": "default"},
         {"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},
 	    {"tag": "protocol_group", "text": "Segmentation", "openItem": "False", "children": []}
     ]}]

--- a/xmipptomo/protocols.conf
+++ b/xmipptomo/protocols.conf
@@ -17,6 +17,7 @@ Tomography = [
         {"tag": "protocol", "value": "XmippProtApplyTransformSubtomo", "text": "default"},
         {"tag": "protocol", "value": "XmippProtUndoAlignSubtomo", "text": "default"},
         {"tag": "protocol", "value": "XmippProtSubtomoMapBack", "text": "default"},
+        {"tag": "protocol", "value": "XmippProtPhantomSubtomo", "text": "default"},
         {"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},
 	    {"tag": "protocol_group", "text": "Segmentation", "openItem": "False", "children": []}
     ]}]

--- a/xmipptomo/protocols.conf
+++ b/xmipptomo/protocols.conf
@@ -4,7 +4,6 @@ Tomography = [
 	{"tag": "section", "text": "Movies/Micrographs", "children": []},
 	{"tag": "section", "text": "Reconstruction", "children": []},
     {"tag": "section", "text": "Particles", "children": [
-        {"tag": "protocol", "value": "XmippProtPhantomSubtomo", "text": "default"},
 		{"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
             {"tag": "protocol", "value": "XmippProtConnectedComponents", "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtRoiIJ",   "text": "default"},
@@ -20,4 +19,7 @@ Tomography = [
         {"tag": "protocol", "value": "XmippProtSubtomoMapBack", "text": "default"},
         {"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},
 	    {"tag": "protocol_group", "text": "Segmentation", "openItem": "False", "children": []}
+    ]},
+        {"tag": "section", "text": "Test", "children": [
+        {"tag": "protocol", "value": "XmippProtPhantomSubtomo", "text": "default"}
     ]}]

--- a/xmipptomo/protocols/__init__.py
+++ b/xmipptomo/protocols/__init__.py
@@ -32,3 +32,4 @@ from .protocol_connected_components import XmippProtConnectedComponents
 from .protocol_roiIJ import XmippProtRoiIJ
 from .protocol_coords_roi import XmippProtCCroi
 from .protocol_cltomo import XmippProtCLTomo
+from .protocol_phantom_subtomo import XmippProtPhantomSubtomo

--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -25,7 +25,6 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-import numpy as np
 
 import pwem
 from pwem.emlib import MDL_IMAGE
@@ -74,19 +73,14 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
         mdWindow = md.MetaData(self._getExtraPath('windowed_subtomograms.xmd'))
         mdWindowTransform = md.MetaData()
         idList = list(inputSt.getIdSet())
-        inputsbt = self.inputSubtomograms.get()
         for row in md.iterRows(mdWindow):
             rowOut = md.Row()
             rowOut.copyFromRow(row)
             id = row.getValue(MDL_IMAGE)
             id = id.split('@')[0]
             id = id.strip('0')
-            transf = inputsbt[(idList[int(id)-1])].getTransform()
-            invMatrix = np.linalg.inv(transf.getMatrix())
-            transf.setMatrix(invMatrix)
-            alignmentToRow(transf, rowOut, pwem.ALIGN_3D)
+            alignmentToRow(inputSt[(idList[int(id)-1])].getTransform(), rowOut, pwem.ALIGN_3D)
             rowOut.addToMd(mdWindowTransform)
-
         mdWindowTransform.write(self._getExtraPath("window_with_original_geometry.xmd"))
         # Align subtomograms
         self.runJob('xmipp_transform_geometry', '-i %s -o %s --apply_transform' %

--- a/xmipptomo/protocols/protocol_phantom_subtomo.py
+++ b/xmipptomo/protocols/protocol_phantom_subtomo.py
@@ -29,7 +29,7 @@ import numpy as np
 from pwem.protocols import EMProtocol
 from pyworkflow.protocol.params import IntParam, FloatParam, EnumParam, PointerParam, StringParam
 from tomo.protocols import ProtTomoBase
-from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition
+from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition, Coordinate3D
 
 
 class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
@@ -87,6 +87,8 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
         subtomobase = SubTomogram()
         acq = TomoAcquisition()
         subtomobase.setAcquisition(acq)
+        coord = Coordinate3D()
+        subtomobase.setCoordinate3D(coord)
         subtomobase.setLocation(fnVol)
         subtomobase.setSamplingRate(self.sampling.get())
         self.outputSet.append(subtomobase)
@@ -100,6 +102,7 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
                         % (fnVol, fnPhantomi, rot, tilt, psi))
             subtomo = SubTomogram()
             subtomo.setAcquisition(acq)
+            subtomo.setCoordinate3D(coord)
             subtomo.setLocation(fnPhantomi)
             subtomo.setSamplingRate(self.sampling.get())
             self.outputSet.append(subtomo)

--- a/xmipptomo/protocols/protocol_phantom_subtomo.py
+++ b/xmipptomo/protocols/protocol_phantom_subtomo.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     Estrella Fernandez Gimenez (me.fernandez@cnb.csic.es)
+# *
+# *  BCU, Centro Nacional de Biotecnologia, CSIC
+# *
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+import numpy as np
+import pwem
+from pwem.protocols import EMProtocol
+from pyworkflow.protocol.params import IntParam
+ProtTomoBase = pwem.Domain.importFromPlugin('tomo.protocols', 'ProtTomoBase', doRaise=True)
+
+class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
+    """ Create subtomogram phantoms """
+
+    _label = 'phantom create subtomo'
+
+    # --------------------------- DEFINE param functions ------------------------
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('nsubtomos', IntParam, label='Number of subtomograms', help="How many phantom subtomograms")
+        form.addParam('dim', IntParam, label='Dimension of subtomograms', help="dimx = dimy = dimz")
+        form.addParam('rotmin', IntParam, label='Min rot angle')
+        form.addParam('rotmax', IntParam, label='Max rot angle')
+        form.addParam('tiltmin', IntParam, label='Min tilt angle')
+        form.addParam('tiltmax', IntParam, label='Max tilt angle')
+        form.addParam('psimin', IntParam, label='Min psi angle')
+        form.addParam('psimax', IntParam, label='Max psi angle')
+
+    # --------------------------- INSERT steps functions --------------------------------------------
+    def _insertAllSteps(self):
+        self._insertFunctionStep('createPhantomsStep')
+
+    # --------------------------- STEPS functions --------------------------------------------
+    def createPhantomsStep(self):
+        fnDescr = self._getExtraPath("phantom.descr")
+        fhDescr = open(fnDescr, 'w')
+        dim = self.dim.get()
+        fhDescr.write("%s %s %s 0\ncyl + 1 0 0 0 15 15 2 0 0 0\nsph + 1 0 0 5 2\ncyl + 1 0 0 -5 2 2 10 0 90 0"
+                      % (dim, dim, dim))
+        fhDescr.close()
+        fnVol = self._getExtraPath("phantom.vol")
+        self.runJob("xmipp_phantom_create", " -i %s -o %s" % (fnDescr, fnVol))
+        for i in range(self.nsubtomos.get()):
+            fnPhantomi = self._getExtraPath("phantom%03d.vol" % i)
+            rot = np.random.randint(self.rotmin.get(), self.rotmax.get())
+            tilt = np.random.randint(self.tiltmin.get(), self.tiltmax.get())
+            psi = np.random.randint(self.psimin.get(), self.psimax.get())
+            self.runJob("xmipp_transform_geometry",
+                        " -i %s -o %s --rotate_volume euler %d %d %d "
+                        % (fnVol, fnPhantomi, rot, tilt, psi))
+
+    # --------------------------- INFO functions --------------------------------------------
+    def _validate(self):
+        errors = []
+        return errors
+
+    def _summary(self):
+        summary = []
+        if not hasattr(self, 'outputSubtomograms'):
+            summary.append("Output phantom not ready yet.")
+        else:
+            summary.append("%s phantoms created with random orientations" % self.nsubtomos.get())
+        return summary
+
+    def _methods(self):
+        if not hasattr(self, 'outputSubtomograms'):
+            return ["Output phantoms not ready yet."]
+        else:
+            return ["%s phantoms created with random orientations" % self.nsubtomos.get()]

--- a/xmipptomo/protocols/protocol_phantom_subtomo.py
+++ b/xmipptomo/protocols/protocol_phantom_subtomo.py
@@ -29,7 +29,7 @@ import numpy as np
 from pwem.protocols import EMProtocol
 from pyworkflow.protocol.params import IntParam, FloatParam, EnumParam, PointerParam, StringParam
 from tomo.protocols import ProtTomoBase
-from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition, Coordinate3D
+from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition
 
 
 class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
@@ -87,8 +87,6 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
         subtomobase = SubTomogram()
         acq = TomoAcquisition()
         subtomobase.setAcquisition(acq)
-        coord = Coordinate3D()
-        subtomobase.setCoordinate3D(coord)
         subtomobase.setLocation(fnVol)
         subtomobase.setSamplingRate(self.sampling.get())
         self.outputSet.append(subtomobase)
@@ -102,7 +100,6 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
                         % (fnVol, fnPhantomi, rot, tilt, psi))
             subtomo = SubTomogram()
             subtomo.setAcquisition(acq)
-            subtomo.setCoordinate3D(coord)
             subtomo.setLocation(fnPhantomi)
             subtomo.setSamplingRate(self.sampling.get())
             self.outputSet.append(subtomo)

--- a/xmipptomo/tests/test_protocols_xmipptomo.py
+++ b/xmipptomo/tests/test_protocols_xmipptomo.py
@@ -259,7 +259,7 @@ class TestXmipptomoPhantom(BaseTest):
         setupTestProject(cls)
 
     def _phantom(self):
-        phantom = self.newProtocol(XmippProtPhantomSubtomo)
+        phantom = self.newProtocol(XmippProtPhantomSubtomo, option=1)
         self.launchProtocol(phantom)
         self.assertIsNotNone(phantom.outputSubtomograms,
                              "There was a problem with subtomograms output")

--- a/xmipptomo/tests/test_protocols_xmipptomo.py
+++ b/xmipptomo/tests/test_protocols_xmipptomo.py
@@ -31,7 +31,7 @@ from tomo.protocols import (ProtImportCoordinates3D,
                             ProtImportSubTomograms)
 
 from xmipptomo.protocols import XmippProtSubtomoProject, XmippProtConnectedComponents, XmippProtApplyTransformSubtomo, \
-    XmippProtSubtomoMapBack
+    XmippProtSubtomoMapBack, XmippProtPhantomSubtomo
 
 
 class TestXmipptomoProtCC(BaseTest):
@@ -249,3 +249,23 @@ class TestXmipptomoMapback(BaseTest):
         mapback = self._mapback()
         self.assertTrue(getattr(mapback, 'outputTomograms'))
         return mapback
+
+
+class TestXmipptomoPhantom(BaseTest):
+    """This class check if the protocol create phantom subtomo works properly."""
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+    def _phantom(self):
+        phantom = self.newProtocol(XmippProtPhantomSubtomo)
+        self.launchProtocol(phantom)
+        self.assertIsNotNone(phantom.outputSubtomograms,
+                             "There was a problem with subtomograms output")
+        return phantom
+
+    def test_phantom(self):
+        phantom = self._phantom()
+        self.assertTrue(getattr(phantom, 'outputSubtomograms'))
+        return phantom


### PR DESCRIPTION
Finally this branch did not need any fix for the transform matrix issue, but it has been developed a protocol to create subtomogram phantoms in order to test properly what is happening when a transform matrix is applied (and maybe in the future to test other issues or protocols). 

The protocol can create n phantoms from a "base phantom" which can be created manually from a phantom description or from an input volume. The rest of n-1 phantoms will be copies of this base phantom but rotated randomly in rot, tilt and psi in the ranges defined by the user.
The output is a SetOfSubtomograms which can be used as input for any protocol that accepts that kind of input.
