### PR TITLE
Jj fix convert

### DIFF
--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -62,11 +62,13 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
         S = self._createSetOfSubTomograms()
         inputSet = self.inputSubtomograms.get()
         S.setSamplingRate(inputSet.getSamplingRate())
-        for subtomo in self.inputSubtomograms.get():
-            s = subtomo.clone()
-            s.setFileName(subtomo.getFileName() + ':mrc')
-            S.append(s)
-        writeSetOfVolumes(S, outputFn, alignType=pwem.ALIGN_3D)
+        if inputSet.getFirstItem().getFileName().endswith('.mrc') or \
+                inputSet.getFirstItem().getFileName().endswith('.map'):
+            for subtomo in self.inputSubtomograms.get():
+                s = subtomo.clone()
+                s.setFileName(subtomo.getFileName() + ':mrc')
+                S.append(s)
+            writeSetOfVolumes(S, outputFn, alignType=pwem.ALIGN_3D)
         return [outputFn]
 
     def applyAlignmentStep(self, inputFn):

--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -59,11 +59,11 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions --------------------------------------------
     def convertInputStep(self, outputFn):
-        S = self._createSetOfSubTomograms()
         inputSet = self.inputSubtomograms.get()
-        S.setSamplingRate(inputSet.getSamplingRate())
         if inputSet.getFirstItem().getFileName().endswith('.mrc') or \
                 inputSet.getFirstItem().getFileName().endswith('.map'):
+            S = self._createSetOfSubTomograms()
+            S.setSamplingRate(inputSet.getSamplingRate())
             for subtomo in self.inputSubtomograms.get():
                 s = subtomo.clone()
                 s.setFileName(subtomo.getFileName() + ':mrc')

--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -59,7 +59,14 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions --------------------------------------------
     def convertInputStep(self, outputFn):
-        writeSetOfVolumes(self.inputSubtomograms.get(), outputFn, alignType=pwem.ALIGN_3D)
+        S = self._createSetOfSubTomograms()
+        inputSet = self.inputSubtomograms.get()
+        S.setSamplingRate(inputSet.getSamplingRate())
+        for subtomo in self.inputSubtomograms.get():
+            s = subtomo.clone()
+            s.setFileName(subtomo.getFileName() + ':mrc')
+            S.append(s)
+        writeSetOfVolumes(S, outputFn, alignType=pwem.ALIGN_3D)
         return [outputFn]
 
     def applyAlignmentStep(self, inputFn):

--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -69,6 +69,8 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
                 s.setFileName(subtomo.getFileName() + ':mrc')
                 S.append(s)
             writeSetOfVolumes(S, outputFn, alignType=pwem.ALIGN_3D)
+        else:
+            writeSetOfVolumes(inputSet, outputFn, alignType=pwem.ALIGN_3D)
         return [outputFn]
 
     def applyAlignmentStep(self, inputFn):


### PR DESCRIPTION
Update subtomogram filename adding :mrc to make xmipp work with the input files as volumes, so the user doesn't have to convert them manually outside Scipion