### PR TITLE
Score Coordinates Protocolo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 scipion-em-xmipp
 scipion-em-tomo
-deepLearningToolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 scipion-em-xmipp
 scipion-em-tomo
+deepLearningToolkit

--- a/xmipptomo/__init__.py
+++ b/xmipptomo/__init__.py
@@ -23,8 +23,8 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-
 import xmipp3
+import subprocess, os
 
 _logo = "xmipp_logo.png"
 _references = ['delaRosaTrevin2013']
@@ -33,4 +33,72 @@ __version__ = "3.0.6"
 class Plugin(xmipp3.Plugin):
     @classmethod
     def defineBinaries(cls, env):
-        pass
+        preMsgs = []
+        cudaMsgs = []
+        nvidiaDriverVer = None
+        if os.environ.get('CUDA', 'True') == 'True':
+            try:
+                nvidiaDriverVer = subprocess.Popen(["nvidia-smi",
+                                                    "--query-gpu=driver_version",
+                                                    "--format=csv,noheader"],
+                                                   env=xmipp3.Plugin.getEnviron(),
+                                                   stdout=subprocess.PIPE
+                                                   ).stdout.read().decode('utf-8').split(".")[0]
+                if int(nvidiaDriverVer) < 390:
+                    preMsgs.append("Incompatible driver %s" % nvidiaDriverVer)
+                    cudaMsgs.append("Your NVIDIA drivers are too old (<390). "
+                                    "Tensorflow was installed without GPU support. "
+                                    "Just CPU computations enabled (slow computations).")
+                    nvidiaDriverVer = None
+            except Exception as e:
+                preMsgs.append(str(e))
+
+        if nvidiaDriverVer is not None:
+            preMsgs.append("CUDA support find. Driver version: %s" % nvidiaDriverVer)
+            msg = "Tensorflow installed with CUDA SUPPORT."
+            cudaMsgs.append(msg)
+            useGpu = True
+        else:
+            preMsgs.append("CUDA will NOT be USED. (not found or incompatible)")
+            msg = ("Tensorflow installed without GPU. Just CPU computations "
+                   "enabled (slow computations). To enable CUDA (drivers>390 needed), "
+                   "set CUDA=True in 'scipion.conf' file")
+            cudaMsgs.append(msg)
+            useGpu = False
+
+        # commands  = [(command, target), (cmd, tgt), ...]
+        cmdsInstall = [(cmd, envName + ".yml") for cmd, envName in
+                       xmipp3.CondaEnvManager.yieldInstallAllCmds(useGpu=useGpu)]
+
+        now = xmipp3.datetime.now()
+        installDLvars = {'modelsUrl': "http://scipion.cnb.csic.es/downloads/scipion/software/em",
+                         'syncBin': cls.getHome('bin/xmipp_sync_data'),
+                         'modelsDir': cls.getHome('models'),
+                         'modelsPrefix': "models_UPDATED_on",
+                         'xmippLibToken': 'xmippLibToken',
+                         'libXmipp': cls.getHome('lib/libXmipp.so'),
+                         'preMsgsStr': ' ; '.join(preMsgs),
+                         'afterMsgs': "\n > ".join(cudaMsgs)}
+
+        installDLvars.update({'modelsTarget': "%s_%s_%s_%s"
+                                              % (installDLvars['modelsPrefix'],
+                                                 now.day, now.month, now.year)})
+
+        modelsDownloadCmd = ("rm %(modelsPrefix)s_* %(xmippLibToken)s 2>/dev/null ; "
+                             "echo 'Downloading pre-trained models...' ; "
+                             "%(syncBin)s update %(modelsDir)s %(modelsUrl)s DLmodels && "
+                             "touch %(modelsTarget)s && echo ' > %(afterMsgs)s'"
+                             % installDLvars,  # End of command
+                             installDLvars['modelsTarget'])  # Target
+
+        xmippInstallCheck = ("if ls %(libXmipp)s > /dev/null ; "
+                             "then touch %(xmippLibToken)s; echo ' > %(preMsgsStr)s' ; "
+                             "else echo ; echo ' > Xmipp installation not found, "
+                             "please install it first (xmippSrc or xmippBin*).';echo;"
+                             " fi" % installDLvars,  # End of command
+                             installDLvars['xmippLibToken'])  # Target
+
+        env.addPackage(xmipp3.constants.XMIPP_DLTK_NAME, version='0.2', urlSuffix='external',
+                       commands=[xmippInstallCheck] + cmdsInstall + [modelsDownloadCmd],
+                       deps=[], tar=xmipp3.constants.XMIPP_DLTK_NAME + '.tgz',
+                       default=True)

--- a/xmipptomo/protocols.conf
+++ b/xmipptomo/protocols.conf
@@ -12,7 +12,8 @@ Tomography = [
             {"tag": "protocol", "value": "XmippProtConnectedComponents", "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtRoiIJ",   "text": "default"},
 		    {"tag": "protocol", "value": "XmippProtCCroi",   "text": "default"},
-            {"tag": "protocol", "value": "XmippProtFitEllipsoid",   "text": "default"}
+            {"tag": "protocol", "value": "XmippProtFitEllipsoid",   "text": "default"},
+            {"tag": "protocol", "value": "XmippProtScoreCoordinates",   "text": "default"}
 		    ]},
 		{"tag": "protocol_group", "text": "Extract", "openItem": "False", "children": []}
     ]},

--- a/xmipptomo/protocols/__init__.py
+++ b/xmipptomo/protocols/__init__.py
@@ -36,3 +36,4 @@ from .protocol_misalignTS import XmippProtMisalignTiltSeries
 from .protocol_splitTS import XmippProtSplitTiltSeries
 from .protocol_flexalign import XmippProtTsFlexAlign
 from .protocol_applyAlignmentTS import XmippProtApplyTransformationMatrixTS
+from .protocol_score_coordinates import XmippProtScoreCoordinates

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -61,7 +61,7 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
                             'filter out unwanted coordinates based on a threshold')
         form.addParam('outliers', params.BooleanParam, default=True,
                       label="Score outluiers?")
-        form.addParam('outliersThreshold', params.FloatParam, default=0.8,
+        form.addParam('outliersThreshold', params.FloatParam, default=1,
                       label="Outliers distance threshold", condition='outliers == True and filter == 1',
                       help='Z-Score value from 0 to infinite')
         form.addParam('carbon', params.BooleanParam, default=True,

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -1,8 +1,6 @@
 # **************************************************************************
 # *
-# * Authors:    Carlos Oscar Sorzano (coss@cnb.csic.es)
-# *             Tomas Majtner (tmajtner@cnb.csic.es)  -- streaming version
-# *             David Herreros Calero (dherreros@cnb.csic.es) -- Tomo version
+# * Authors:    David Herreros Calero (dherreros@cnb.csic.es)
 # *
 # * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -44,7 +44,7 @@ from tomo.utils import extractVesicles, initDictVesicles
 
 class XmippProtScoreCoordinates(ProtTomoPicking):
     '''Scoring and (optional) filtering of coordinates based on different scoring
-    functions (normals angle, carbon distance, neighbour distance)'''
+    functions (carbon distance, neighbour distance)'''
 
     _label = 'score/filter coordinates'
 
@@ -57,7 +57,7 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
         form.addParam('filter', params.EnumParam, choices=['score', 'filter'],
                        default=0, display=params.EnumParam.DISPLAY_HLIST,
                        label='Operation mode',
-                       help='Deterimen wheter to retrieve all the coordinates scored or to '
+                       help='Determine whether to retrieve all the coordinates scored or to '
                             'filter out unwanted coordinates based on a threshold')
         form.addParam('outliers', params.BooleanParam, default=True,
                       label="Score outluiers?")

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -108,7 +108,6 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
         z_scores = np.abs((distribution - np.mean(distribution)) / np.std(distribution))
         for idn in range(len(self.scoreOutliers)):
             self.scoreOutliers[idn][1] = z_scores[idn]
-            print('JAJAJAJAJAJAJAJAJAJAJAJAJAJAJA')
 
     def detectCarbonCloseness(self, coordinates):
         # self.scoreCarbon = {}

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -38,7 +38,8 @@ from xmipp3.convert import (openMd, readPosCoordinates, rowToCoordinate,
                             rowFromMd)
 
 from tomo.protocols import ProtTomoPicking
-from tomo.utils import delaunayTriangulation, extractVesicles
+from tomo3D.utils import delaunayTriangulation
+from tomo.utils import extractVesicles
 
 
 class XmippProtScoreCoordinates(ProtTomoPicking):

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -1,0 +1,226 @@
+# **************************************************************************
+# *
+# * Authors:    Carlos Oscar Sorzano (coss@cnb.csic.es)
+# *             Tomas Majtner (tmajtner@cnb.csic.es)  -- streaming version
+# *             David Herreros Calero (dherreros@cnb.csic.es) -- Tomo version
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'coss@cnb.csic.es'
+# *
+# **************************************************************************
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+import pyworkflow.protocol.params as params
+import pyworkflow.utils as pwutils
+from pyworkflow.object import Float
+
+from pwem.emlib.image import ImageHandler
+import pwem.emlib.metadata as md
+
+from xmipp3.convert import (openMd, readPosCoordinates, rowToCoordinate,
+                            rowFromMd)
+
+from tomo.protocols import ProtTomoPicking
+from tomo.utils import delaunayTriangulation, extractVesicles
+
+
+class XmippProtScoreCoordinates(ProtTomoPicking):
+    '''Scoring and (optional) filtering of coordinates based on different scoring
+    functions (normals angle, carbon distance, neighbour distance)'''
+
+    _label = 'score/filter coordinates'
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputCoordinates', params.PointerParam,
+                      pointerClass='SetOfCoordinates3D',
+                      label="Input 3D coordinates", important=True,
+                      help='Select the set of 3D coordinates to compare')
+        form.addParam('filter', params.EnumParam, choices=['score', 'filter'],
+                       default=0, display=params.EnumParam.DISPLAY_HLIST,
+                       label='Operation mode',
+                       help='Deterimen wheter to retrieve all the coordinates scored or to '
+                            'filter out unwanted coordinates based on a threshold')
+        form.addParam('outliers', params.BooleanParam, default=True,
+                      label="Score outluiers?")
+        form.addParam('outliersThreshold', params.FloatParam, default=0.8,
+                      label="Outliers distance threshold", condition='outliers == True and filter == 1',
+                      help='Score value between 0 and 1')
+        form.addParam('angle', params.BooleanParam, default=True,
+                      label="Score normals?")
+        form.addParam('angleThreshold', params.FloatParam, default=0.8,
+                      label="Angle threshold", condition='angle == True and filter == 1',
+                      help='Score value between 0 and 1')
+        form.addParam('carbon', params.BooleanParam, default=True,
+                      label="Score carbon closeness?")
+        form.addParam('carbonThreshold', params.FloatParam, default=0.8,
+                      label="Carbon distance threshold", condition='outliers == True and filter == 1',
+                      help='Score value between 0 and 1')
+
+    # --------------------------- INSERT steps functions ----------------------
+    def _insertAllSteps(self):
+        pwutils.makePath(self._getExtraPath('inputCoords'))
+        pwutils.makePath(self._getExtraPath('outputCoords'))
+        coordinates = self.inputCoordinates.get()
+        self.tomos = coordinates.getPrecedents()
+        self.tomoNames = [pwutils.removeBaseExt(tomo.getFileName()) for tomo in self.tomos]
+        self._insertFunctionStep('computeParams', coordinates)
+        if self.outliers.get():
+            self._insertFunctionStep('detectOutliers')
+        if self.carbon.get():
+            self._insertFunctionStep('detectCarbonCloseness', coordinates)
+        self._insertFunctionStep('createOutputStep', coordinates)
+
+    def computeParams(self, coordinates):
+        self.tomo_vesicles = extractVesicles(coordinates)
+
+    def detectOutliers(self):
+        self.scoreOutliers = {}
+        # threshold = np.exp(-self.outliersThreshold.get())
+        for tomoName in self.tomoNames:
+            self.scoreOutliers[tomoName] = []
+            for idv, vesicle in enumerate(self.tomo_vesicles[tomoName]['vesicles']):
+                tree = cKDTree(vesicle)
+                for idp, point in enumerate(vesicle):
+                    distance, _ = tree.query(point, k=2)
+                    self.scoreOutliers[tomoName].append((self.tomo_vesicles[tomoName]['ids'][idv][idp],
+                                                         np.exp(-distance[1])))
+
+    def detectCarbonCloseness(self, coordinates):
+        self.scoreCarbon = {}
+        for tomo, tomoName in zip(self.tomos.iterItems(), self.tomoNames):
+            self.scoreCarbon[tomoName] = []
+            projFile, dfactor = self.projectTomo(tomo)
+            coordList = self.generateCoordList(tomo, coordinates, dfactor)
+            self.writeTomoCoordinates(tomo, coordList, self._getTomoPos(projFile))
+            args = '-i %s -c %s -o %s -b %d' \
+                   % (projFile, self._getExtraPath('inputCoords'),
+                      self._getExtraPath('outputCoords'), coordinates.getBoxSize() // dfactor)
+            self.runJob('xmipp_deep_micrograph_cleaner', args)
+            baseName = pwutils.removeBaseExt(projFile)
+            outFile = self._getExtraPath('outputCoords', baseName + ".pos")
+            posMd = readPosCoordinates(outFile)
+            posMd.addLabel(md.MDL_ITEM_ID)
+            for objId in posMd:
+                if posMd.getValue(md.MDL_ENABLED, objId) == 0:
+                    posMd.setValue(md.MDL_ENABLED, 1, objId)
+                coord = rowToCoordinate(rowFromMd(posMd, objId))
+                self.scoreCarbon[tomoName].append((objId,
+                                                   coord._xmipp_goodRegionScore.get()))
+
+    def createOutputStep(self, coordinates):
+        outSet = self._createSetOfCoordinates3D(coordinates)
+        outSet.setPrecedents(coordinates.getPrecedents())
+        outSet.setBoxSize(coordinates.getBoxSize())
+        outSet.setSamplingRate(coordinates.getSamplingRate())
+
+        for tomo, tomoName in zip(self.tomos, self.tomoNames):
+            scoreOutliers = sorted(self.scoreOutliers[tomoName], key=lambda tup: tup[0])
+            scoreCarbon = sorted(self.scoreCarbon[tomoName], key=lambda tup: tup[0])
+            for tupleCarbon, tupleOutlier in zip(scoreCarbon, scoreOutliers):
+                newCoord = coordinates[tupleCarbon[0]].clone()
+                newCoord.setBoxSize(outSet.getBoxSize())
+                newCoord.setVolume(tomo)
+                if self.filter.get():
+                    if self.outliers.get() and self.outliersThreshold.get() <= tupleOutlier[1]:
+                        newCoord.outlierScore = Float(tupleOutlier[1])
+                    else:
+                        continue
+                    if self.carbon.get() and self.carbonThreshold.get() <= tupleCarbon[1]:
+                        newCoord.carbonScore = Float(tupleCarbon[1])
+                    else:
+                        continue
+                    outSet.append(newCoord)
+                else:
+                    if self.outliers.get():
+                        newCoord.outlierScore = Float(tupleOutlier[1])
+                    if self.carbon.get():
+                        newCoord.carbonScore = Float(tupleCarbon[1])
+                    outSet.append(newCoord)
+        self._defineOutputs(outputCoordinates=outSet)
+        self._defineSourceRelation(coordinates, outSet)
+
+
+    # --------------------------- UTILS functions ----------------------
+    def projectTomo(self, tomo):
+        dfactor = None
+        outFile = pwutils.removeBaseExt(tomo.getFileName()) + '_projected.mrc'
+        ih = ImageHandler()
+        outProjection = ih.createImage()
+        tomoData = np.squeeze(ih.read(tomo.getFileName()).getData())
+        projection = np.sum(tomoData, axis=0)
+        outProjection.setData(projection)
+        ih.write(outProjection, self._getExtraPath(outFile))
+        bgDim = max(projection.shape)
+        if bgDim > 200:  # Mejor 500
+            dfactor = bgDim / 200
+            args = '-i %s --step %f --method fourier' % \
+                   (self._getExtraPath(outFile), dfactor)
+            self.runJob("xmipp_transform_downsample", args)
+        return self._getExtraPath(outFile), dfactor
+
+    def _getTomoPos(self, fileName):
+        """ Return the corresponding .pos file for a given tomogram. """
+        baseName = pwutils.removeBaseExt(fileName)
+        return self._getExtraPath('inputCoords', baseName + ".pos")
+
+    def writeTomoCoordinates(self, tomo, coordList, outputFn, isManual=True,
+                             getPosFunc=None):
+        """ Write the pos file as expected by Xmipp with the coordinates
+        of a given tomogram.
+        Params:
+            tomo: input tomogram.
+            coordList: list of (x, y) pairs of the mic coordinates.
+            outputFn: output filename for the pos file .
+            isManual: if the coordinates are 'Manual' or 'Supervised'
+            getPosFunc: a function to get the positions from the coordinate,
+                it can be useful for scaling the coordinates if needed.
+        """
+        if getPosFunc is None:
+            getPosFunc = lambda coord: coord.getPosition()
+
+        state = 'Manual' if isManual else 'Supervised'
+        f = openMd(outputFn, state)
+
+        for coord in coordList:
+            x, y, z = getPosFunc(coord)
+            f.write(" %06d   1   %d  %d  %d   %06d \n"
+                    % (coord.getObjId(), x, y, 1, tomo.getObjId()))
+
+        f.close()
+
+    def generateCoordList(self, tomo, coordinates, dfactor):
+        if dfactor is not None:
+            coordList = []
+            for coord in coordinates.iterCoordinates(volume=tomo):
+                cloned_coord = coord.clone()
+                x, y, z = cloned_coord.getPosition()
+                cloned_coord.setPosition(x / dfactor,
+                                         y / dfactor,
+                                         z / dfactor)
+                coordList.append(cloned_coord)
+            return coordList
+        else:
+            return [coord.clone() for coord in coordinates.iterCoordinates(volume=tomo)]
+
+    # --------------------------- INFO functions ----------------------
+

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -108,12 +108,14 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
         z_scores = np.abs((distribution - np.mean(distribution)) / np.std(distribution))
         for idn in range(len(self.scoreOutliers)):
             self.scoreOutliers[idn][1] = z_scores[idn]
+            print('JAJAJAJAJAJAJAJAJAJAJAJAJAJAJA')
 
     def detectCarbonCloseness(self, coordinates):
-        self.scoreCarbon = {}
+        # self.scoreCarbon = {}
         self.scoreCarbon = []
-        for idt, tomoName in enumerate(self.tomoNames):
-            tomo = self.tomos[idt+1].clone()
+        for tomoName in self.tomoNames:
+            idt = self.tomo_vesicles[tomoName]["volId"]
+            tomo = self.tomos[idt].clone()
             projFile = self.projectTomo(tomo)
             inputTomoPathMetadataFname = self._getTmpPath("inputTomo.xmd")
             tomo_md = createMetaDataFromPattern(projFile)
@@ -134,6 +136,7 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
                 coord = rowToCoordinate(rowFromMd(posMd, objId))
                 self.scoreCarbon.append([posMd.getValue(md.MDL_ITEM_ID, objId),
                                          coord._xmipp_goodRegionScore.get()])
+            pwutils.cleanPath(projFile)
 
     def createOutputStep(self, coordinates):
         outSet = self._createSetOfCoordinates3D(coordinates)

--- a/xmipptomo/tests/test_protocols_xmipptomo.py
+++ b/xmipptomo/tests/test_protocols_xmipptomo.py
@@ -31,7 +31,7 @@ from tomo.protocols import (ProtImportCoordinates3D,
                             ProtImportSubTomograms)
 
 from xmipptomo.protocols import XmippProtSubtomoProject, XmippProtConnectedComponents, XmippProtApplyTransformSubtomo, \
-    XmippProtSubtomoMapBack, XmippProtPhantomSubtomo
+    XmippProtSubtomoMapBack, XmippProtPhantomSubtomo, XmippProtScoreCoordinates
 
 
 class TestXmipptomoProtCC(BaseTest):
@@ -229,7 +229,7 @@ class TestXmipptomoMapback(BaseTest):
         self.launchProtocol(protImportCoordinates3d)
         self.assertIsNotNone(protImportCoordinates3d.outputCoordinates,
                              "There was a problem with coordinates 3d output")
-        from eman2.protocols import EmanProtTomoExtraction
+        from emantomo.protocols import EmanProtTomoExtraction
         protTomoExtraction = self.newProtocol(EmanProtTomoExtraction,
                                               inputTomograms=protImportTomogram.outputTomograms,
                                               inputCoordinates=protImportCoordinates3d.outputCoordinates,
@@ -313,3 +313,76 @@ class TestXmipptomoPhantom(BaseTest):
         phantom = self._phantom()
         self.assertTrue(getattr(phantom, 'outputSubtomograms'))
         return phantom
+
+
+class XmippTomoScoreCoordinates(BaseTest):
+    """This class check if the protocol project top works properly."""
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dataset = DataSet.getDataSet('tomo-em')
+        cls.tomogram = cls.dataset.getFile('overview_wbp.em')
+
+    def _runPreviousProtocols(self):
+        protImportTomogram = self.newProtocol(ProtImportTomograms,
+                                      filesPath=self.tomogram,
+                                      samplingRate=2,
+                                      objLabel='Import Tomogram')
+        self.launchProtocol(protImportTomogram)
+        output = getattr(protImportTomogram, 'outputTomograms', None)
+        self.assertIsNotNone(output,
+                             "There was a problem with import tomograms output")
+
+        protImportCoordinates3d = self.newProtocol(ProtImportCoordinates3D,
+                                                   objLabel='Import Coordinates - JSON',
+                                                   auto=0,
+                                                   filesPath=self.dataset.getPath(),
+                                                   importTomograms=protImportTomogram.outputTomograms,
+                                                   filesPattern='*.json', boxSize=32,
+                                                   samplingRate=5)
+        self.launchProtocol(protImportCoordinates3d)
+        output = getattr(protImportCoordinates3d, 'outputCoordinates', None)
+        self.assertIsNotNone(output,
+                             "There was a problem with import coordinates output")
+
+        return protImportCoordinates3d
+
+    def _createProtScoreCarbon(self, protCoords):
+        protScoreCoordinates = self.newProtocol(XmippProtScoreCoordinates,
+                                                objLabel='Filter Carbon - Threshold 0.8',
+                                                inputCoordinates=protCoords.outputCoordinates,
+                                                filter=1,
+                                                outliers=False)
+        self.launchProtocol(protScoreCoordinates)
+        return getattr(protScoreCoordinates, 'outputCoordinates')
+
+    def _createProtScoreOutliers(self, protCoords):
+        protScoreCoordinates = self.newProtocol(XmippProtScoreCoordinates,
+                                                objLabel='Filter Outliers - Threshold 1',
+                                                inputCoordinates=protCoords.outputCoordinates,
+                                                filter=1,
+                                                carbon=False)
+        self.launchProtocol(protScoreCoordinates)
+        return getattr(protScoreCoordinates, 'outputCoordinates')
+
+    def test_score_coordinates(self):
+
+        # Run imports
+        protCoords = self._runPreviousProtocols()
+
+        # Test Carbon based filtering
+        filteredCoords = self._createProtScoreCarbon(protCoords)
+        self.assertTrue(filteredCoords,
+                        "There was a problem with score coordinates output")
+        self.assertTrue(filteredCoords.getSize() == 4)
+        self.assertTrue(filteredCoords.getBoxSize() == 32)
+        self.assertTrue(filteredCoords.getSamplingRate() == 5)
+
+        # Test Outlier based filtering
+        filteredCoords = self._createProtScoreOutliers(protCoords)
+        self.assertTrue(filteredCoords,
+                        "There was a problem with score coordinates output")
+        self.assertTrue(filteredCoords.getSize() == 14)
+        self.assertTrue(filteredCoords.getBoxSize() == 32)
+        self.assertTrue(filteredCoords.getSamplingRate() == 5)


### PR DESCRIPTION
New protocol added to score/filter coordinates based on two criteria:

- Outliers: Discard or score the coordinates depending on their neighbour distances to detect outliers in the set.
- Carbon: Execution of "xmipp_deep_micrograph_cleaner" to filter/score coordinates according to their distance to the carbon in the Tomogram.

The carbon scoring system needs the binaries defined by `deepLearningToolkit` to be executed properly. This package has been added to the `requirements.txt` file so it is installed automatically during protocol installation.