### PR TITLE
XmippTomo: Fix filename of averages

### DIFF
--- a/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
+++ b/xmipptomo/protocols/protocol_apply_alignment_subtomo.py
@@ -121,7 +121,7 @@ class XmippProtApplyTransformSubtomo(EMProtocol, ProtTomoBase):
         avgImage = imgh.computeAverage(alignedSet)
         avgImage.write(avgFile)
         avg = AverageSubTomogram()
-        avg.setLocation(1, avgFile)
+        avg.setLocation(avgFile)
         avg.copyInfo(alignedSet)
         self._defineOutputs(outputAverage=avg)
         self._defineSourceRelation(self.inputSubtomograms, avg)

--- a/xmipptomo/protocols/protocol_half_maps_subtomos.py
+++ b/xmipptomo/protocols/protocol_half_maps_subtomos.py
@@ -147,7 +147,7 @@ class XmippProtHalfMapsSubtomo(EMProtocol, ProtTomoBase):
             avgImage = imgh.computeAverage(alignedSet)
             avgImage.write(avgFile)
             avg = AverageSubTomogram()
-            avg.setLocation(1, avgFile)
+            avg.setLocation(avgFile)
             avg.copyInfo(alignedSet)
             setOfAverageSubTomograms.append(avg)
         self._defineOutputs(halfMaps=setOfAverageSubTomograms)


### PR DESCRIPTION
The filename of averages has been fixed in protocols `protocol_apply_alignment_subtomo` and  `protocol_half_maps_subtomos` so it does not include the index.

This solves the issue of opening the maps with Chimera from the Java interface.