### PR TITLE
phantom_subtomo: fix rotation of phantoms when generated from volumes

### DIFF
--- a/xmipptomo/protocols/protocol_phantom_subtomo.py
+++ b/xmipptomo/protocols/protocol_phantom_subtomo.py
@@ -118,7 +118,7 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
                             % (mwangle, mwangle, fnInVol, fnVol))
             else:
                 mwangle = 90
-                self.runJob("xmipp_image_convert", " -i %s -o %s" % (fnInVol, fnVol))
+                self.runJob("xmipp_image_convert", " -i %s -o %s --type vol" % (fnInVol, fnVol))
         else:
             desc = self.create.get()
             fnDescr = self._getExtraPath("phantom.descr")
@@ -168,7 +168,6 @@ class XmippProtPhantomSubtomo(EMProtocol, ProtTomoBase):
 
             self.runJob("xmipp_transform_geometry", " -i %s -o %s --rotate_volume euler %d %d %d --shift %d %d %d --dont_wrap"
                         % (fnVol, fnPhantomi, rot, tilt, psi, shiftX, shiftY, shiftZ))
-
             if mwfilter:
                 self.runJob("xmipp_transform_filter", " --fourier wedge -%d %d 0 0 0 -i %s -o %s"
                             % (mwangle, mwangle, fnPhantomi, fnPhantomi))


### PR DESCRIPTION
Only when creating phantoms from the input volume **without** simulating missing wedge, the program in charge of creating the base subtomo is `xmipp_image_convert` and this program was not doing the .mrc to .mrc conversion correctly, because it basically should change the name, but it was understanding that it had to convert from a .mrc volume to a .mrc stack. To fix this, it is just need to pass the flag to tell the program that the output file must be a volume.