### PR TITLE
Phantom tomo: allow heterogeneity (2 particles), improve noise, sets …

### DIFF
--- a/xmipptomo/protocols/protocol_phantom_tomo.py
+++ b/xmipptomo/protocols/protocol_phantom_tomo.py
@@ -34,6 +34,7 @@ from pwem.objects.data import Integer
 from pwem.protocols import EMProtocol
 from pyworkflow import BETA
 from pyworkflow.protocol.params import IntParam, FloatParam, StringParam, BooleanParam
+from pyworkflow.utils import removeBaseExt
 from tomo.protocols import ProtTomoBase
 from tomo.objects import TomoAcquisition, Coordinate3D, SetOfCoordinates3D, SetOfTomograms,Tomogram
 import tomo.constants as const
@@ -71,6 +72,9 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
 
         form.addParam('addNoise', BooleanParam, label="Add noise to the tomogram.", default=True,
                       help="Add noise using xmipp_transform.")
+
+        form.addParam('heterogeneous', BooleanParam, label="2 particles?",
+                      default=False, help="Add 2 different particles to allow for 3d classification")
 
         # Angles
         form.addSection(label='Rotation')
@@ -175,10 +179,18 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
                 pos = positions[posIndex]
                 del positions[posIndex]
 
-                # Want to generate a cone --> con + 3 0 0 0 8 30 0 0 0
-                desc += self.getParticleShape(boxSize, i, pos, rot, tilt, psi)
+                # Heterogeneity, if active every even particle.
+                if i % 2 == 1 and self.heterogeneous.get():
+                    classId = 2
+                    altShape= True
+                else:
+                    classId = 1
+                    altShape = False
 
-                coords.append(self._createCoordinate(pos[0],pos[1],pos[2], rot, tilt, psi))
+                # Want to generate a cone --> con + 3 0 0 0 8 30 0 0 0
+                desc += self.getParticleShape(boxSize, i, pos, rot, tilt, psi, alternative=altShape)
+
+                coords.append(self._createCoordinate(pos[0],pos[1],pos[2], rot, tilt, psi, classId))
 
 
             # Write the description
@@ -190,7 +202,7 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
 
         # Add noise
         if self.addNoise.get():
-            self.runJob("xmipp_transform_add_noise",  "-i %s -o %s --type gaussian -80 5" % (fnVol, fnVol))
+            self.runJob("xmipp_transform_add_noise",  "-i %s -o %s --type gaussian 60 0" % (fnVol, fnVol))
 
         setMRCSamplingRate(fnVol, self.sampling.get())
 
@@ -198,7 +210,7 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
         tomo = Tomogram()
         tomo.setAcquisition(acq)
         tomo.setLocation(fnVol)
-
+        tomo.setTsId(removeBaseExt(fnVol))
         self.tomoSet.append(tomo)
 
         # Now that we have the tomogram persisted, we persist the coordinates
@@ -207,9 +219,12 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
             coord.setVolume(tomo)
             self.coords.append(coord)
 
-    def getParticleShape(self, boxSize, i, pos, rot, tilt, psi):
+    def getParticleShape(self, boxSize, i, pos, rot, tilt, psi, alternative=False):
         """ Returns the description for the phantom create. See specs here:
         https://web.archive.org/web/20180813105422/http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/FileFormats#Phantom_metadata_file
+
+
+            param: alternative (False) return an alternative shape to have a second particle
         """
 
         value = -100 - i
@@ -218,7 +233,10 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
 
         # Try a more sophisticated one
         # X axis: a bar
-        shape = "cub = %s %s %s %s %s 5 5 %s %s %s\n" % (value, pos[0]-2, pos[1], pos[2], maxDim, rot, tilt, psi)
+
+        shift = 4 if not alternative else -4
+
+        shape = "cub = %s %s %s %s %s 5 5 %s %s %s\n" % (value, pos[0]-shift, pos[1], pos[2], maxDim, rot, tilt, psi)
         # # Y axis: an ellipsoid
         shape = shape + "ell = %s %s %s %s 5 %s 5 %s %s %s'\n" % (value, pos[0], pos[1]+2, pos[2], maxDim/3, rot, tilt, psi)
         # # Z axis: a cone
@@ -236,16 +254,16 @@ class XmippProtPhantomTomo(EMProtocol, ProtTomoBase):
         # Get the random values
         return rot, tilt, psi
 
-    def _createCoordinate(self, x, y, z, rot, tilt, psi):
+    def _createCoordinate(self, x, y, z, rot, tilt, psi, groupId):
         """ Creates a Coordinate3D with the right transfomation matrix"""
 
         coord = Coordinate3D()
         coord.setX(x, const.SCIPION)
         coord.setY(y, const.SCIPION)
         coord.setZ(z, const.SCIPION)
-
+        coord.setGroupId(groupId)
         coord.setObjComment(
-            "Angle Rot, tilt, psi: %d, %d, %d" % (rot, tilt, psi))
+            "Angle Rot, tilt, psi: %d, %d, %d | group: %s" % (rot, tilt, psi, groupId))
         coord.phantom_rot = Integer(rot)
         coord.phantom_tilt = Integer(tilt)
         coord.phantom_psi = Integer(psi)

--- a/xmipptomo/protocols/protocol_resize_tomograms.py
+++ b/xmipptomo/protocols/protocol_resize_tomograms.py
@@ -99,8 +99,6 @@ class XmippProtResizeTomograms(XmippProtResizeBase):
         newTomogram = Tomogram()
         tomo = self.inputSet.get()[tomId]
         newTomogram.copyInfo(tomo)
-        newTomogram.copyAttributes(tomo, '_origin')
-
         newTomogram.setLocation(outputTomo)
 
         newTomogram.setSamplingRate(self.samplingRate)

--- a/xmipptomo/protocols/protocol_subtomo_map_back.py
+++ b/xmipptomo/protocols/protocol_subtomo_map_back.py
@@ -164,10 +164,11 @@ class XmippProtSubtomoMapBack(EMProtocol, ProtTomoBase):
                     nRow.setValue(lib.MDL_YCOOR, int(coord.getY(const.BOTTOM_LEFT_CORNER)*scaleFactor))
                     nRow.setValue(lib.MDL_ZCOOR, int(coord.getZ(const.BOTTOM_LEFT_CORNER)*scaleFactor))
                     # Compute inverse matrix
-                    A = subtomo.getTransform().getMatrix()
-                    subtomo.getTransform().setMatrix(np.linalg.inv(A))
+                    #A = subtomo.getTransform().getMatrix()
+                    #subtomo.getTransform().setMatrix(np.linalg.inv(A))
                     # Convert transform matrix to Euler Angles (rot, tilt, psi)
-                    alignmentToRow(subtomo.getTransform(), nRow, ALIGN_3D)
+                    from pwem import ALIGN_PROJ
+                    alignmentToRow(subtomo.getTransform(convention="xmipp"), nRow, ALIGN_PROJ)
                     nRow.addToMd(mdGeometry)
             fnGeometry = self._getExtraPath("geometry%d.xmd" % classId)
             mdGeometry.write(fnGeometry)


### PR DESCRIPTION
…tsId, groupId

Resize tomogram: does not need copyAttributes anymore. Done inside copyInfo.
Fix mapback orientations

https://github.com/scipion-em/scipion-em-tomo/pull/217 has to be accepted first