### PR TITLE
Actions: Show compile log if compilation fails

### DIFF
--- a/.github/workflows/buildPlugin.yml
+++ b/.github/workflows/buildPlugin.yml
@@ -75,8 +75,9 @@ jobs:
       env:
         BUILD_TESTS: True
       run: |
-        ../scipion/scipion3 run ./xmipp
+        ../scipion/scipion3 run ./xmipp || (cat compileLOG.txt && false)
         cat compileLOG.txt
+    #TODO: Remove last "cat compileLOG.txt" once there is a new Scipion release
       
     # Checkout scipion-em-xmipp to Pull Request branch if exists, else to devel
     - name: Conditionally checkout scipion-em-xmipp to ${{ github.head_ref }}


### PR DESCRIPTION
It won't do anything until there is a new Scipion release. That's because in the current release version, running scipion run <command>, always retuns 0 (as if command completed successfully), while the command could have failed.

This is fixed in devel, but, until next release, I'll be leaving the cat compileLOG.txt command always active just in case.