### PR TITLE
Project subtomograms: Added angles from Tilt Series

### DIFF
--- a/xmipptomo/protocols/protocol_extract_particlestacks.py
+++ b/xmipptomo/protocols/protocol_extract_particlestacks.py
@@ -27,18 +27,17 @@
 import os
 import glob
 from pwem.emlib import lib
-from pwem.objects import Particle, Volume, Transform, String, SetOfVolumes, SetOfParticles, ImageDim
+from pwem.objects import Transform, ImageDim
 from pwem.protocols import EMProtocol
 from pwem import ALIGN_PROJ
 import pwem.emlib.metadata as md
-import pwem.emlib.image.image_handler as ih
 
 from pyworkflow import BETA
 from pyworkflow.protocol.params import PointerParam, IntParam, BooleanParam
 
 from tomo.objects import SetOfCTFTomoSeries, SetOfTiltSeries, SetOfCoordinates3D, TomoAcquisition, MATRIX_CONVERSION
 from ..objects import SetOfTiltSeriesParticle, TiltSeriesParticle
-from ..utils import writeMdTiltSeries, calculateRotationAngleAndShiftsFromTM
+from ..utils import writeMdTiltSeries, calculateRotationAngleAndShiftsFromTM, getCTFfromId
 import tomo.constants as const
 
 from tomo.protocols import ProtTomoBase
@@ -204,7 +203,7 @@ class XmippProtExtractParticleStacks(EMProtocol, ProtTomoBase):
         sorted_Idx_doseValueInTS = sorted(range(len(doseValueInTS)), key=lambda k: doseValueInTS[k])
 
         doseValueInTSCTF = []
-        ctfTomo = self.getCTFfromId(self.ctfTomoSeries.get(), tsId)
+        ctfTomo = getCTFfromId(self.ctfTomoSeries.get(), tsId)
         ctfList = []
         tiltSeriesFromCTF = ctfTomo.getTiltSeries()
 
@@ -259,12 +258,6 @@ class XmippProtExtractParticleStacks(EMProtocol, ProtTomoBase):
 
         mdts.write(fnts)
         return fnts
-
-    def getCTFfromId(self, setofctftomoseries, targetTsId):
-        for ctfts in setofctftomoseries:
-            ctfId = ctfts.getTsId()
-            if targetTsId == ctfId:
-                return ctfts
 
     def extractStackStep(self, objId):
         """ This function executes xmipp_tomo_extract_particlestacks. To do that

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -216,7 +216,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         params = '-i {}'.format(self.getSubtomogramAbsolutePath(subtomogram))   # Path to subtomogram
         params += ' -o {}'.format(self.getProjectionAbsolutePath(subtomogram))  # Path to output projection
         params += ' --method {}'.format(self.getMethodValue())                  # Projection algorithm
-        params += ' --params {}'.format(self.getXmippParamPath(tsId=tsId))      # Path to Xmipp phantom param file
+        params += ' --params {}'.format(self.getXmippParamPath(tsId=tsId))      # Path to Xmipp param file
         self.runJob("xmipp_phantom_project", params)
     
     def renameMetadataFile(self, metadataFile: str):

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -168,7 +168,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         # Generating projections for each subtomogram
         generationDeps = []
         for subtomogram in self.inputSubtomograms.get():
-            tsId = '' if self.tiltTypeGeneration.get() != self.TYPE_TILT_SERIES else subtomogram.getCoordinate3D().getTomoId()
+            tsId = '' if self.tiltTypeGeneration.get() != self.TYPE_TILT_SERIES or len([ts for ts in self.tiltRangeTS.get()]) == 1 else subtomogram.getCoordinate3D().getTomoId()
             generationDeps.append(self._insertFunctionStep(self.generateSubtomogramProjections, subtomogram.getFileName(), tsId, prerequisites=paramDeps))
         
         # Conditionally removing temporary files
@@ -192,7 +192,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         if self.tiltTypeGeneration.get() == self.TYPE_TILT_SERIES:
             content += "# Projection angles file. Used when projection angles are read instead of calculated\n"
             content += f"_projAngleFile {self.getAngleFileAbsolutePath(tsId)}\n"
-            #"_projAngleFile /data/relocated/ScipionUserData/projects/Pruebas/Runs/003193_XmippProtProjectSubtomograms/extra/reference.xmd\n"
         else:
             content += '# Rotation range and number of samples [Start Finish NSamples]\n'
             content += '_projRotRange    \'0 0 1\'\n'
@@ -317,7 +316,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
             errors.append('The step must be greater than 0.')
         
         # Checking if input projectable set can be related to Tilt Series when TS is selected as angle extraction method
-        if self.tiltTypeGeneration.get() == self.TYPE_TILT_SERIES and len([ti for ti in self.tiltRangeTS.get()]) > 1:
+        if self.tiltTypeGeneration.get() == self.TYPE_TILT_SERIES and len([ts for ts in self.tiltRangeTS.get()]) > 1:
             # Initializing empty error string
             error = ''
 
@@ -341,7 +340,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
             if error:
                 errors.append('In order to use Tilt Series as a method of angle extraction, at least one of the following conditions must be met:\n'
                             '\t- There must be only one Tilt Series within the input set of Tilt Series.\n'
-                            '\t- The input subtomograms must be subtomograms (not volumes) and they must contain coordinates that lead to one of the input Tilt Series.\n\n'
+                            '\t- The input subtomograms must be subtomograms (not volumes) and they must contain coordinates that lead to one of the input Tilt Series.\n'
                             f'In this case, the following validation error occured:\n{error}')
         
         # Checking if MPI is selected (only threads are allowed)
@@ -558,8 +557,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
                 angleDict[tsId] = []
                 for ti in ts:
                     # Add each angle tilt and rotation to the list
-                    angleDict[tsId].append({self.COLUMN_ANGLE_ROT: 0.0, self.COLUMN_ANGLE_TILT: ti.getTiltAngle()})
-                    #angleDict[tsId].append({self.COLUMN_ANGLE_ROT: calculateRotationAngleAndShiftsFromTM(ti)[0], self.COLUMN_ANGLE_TILT: ti.getTiltAngle()})
+                    angleDict[tsId].append({self.COLUMN_ANGLE_ROT: calculateRotationAngleAndShiftsFromTM(ti)[0], self.COLUMN_ANGLE_TILT: ti.getTiltAngle()})
 
         # Returning result dictionary
         return angleDict

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -205,18 +205,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
 
         return errors
 
-    def _summary(self):
-        """
-        This method usually returns a summary of the text provided by '_methods'.
-        """
-        return []
-
-    def _methods(self):
-        """
-        This method returns a text intended to be copied and pasted in the paper section 'materials & methods'.
-        """
-        return []
-
     # --------------------------- UTILS functions --------------------------------------------
     def scapePath(self, path):
         """

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -37,7 +37,7 @@ from pyworkflow.protocol import params
 
 # External plugin imports
 from tomo.protocols import ProtTomoBase
-from tomo.objects import SubTomogram
+from tomo.objects import SubTomogram, SetOfSubTomograms
 from xmipp3.convert import readSetOfParticles
 
 # Protocol output variable name
@@ -175,8 +175,12 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         dimensions = self.getSubtomogramDimensions().split(' ')
         outputSetOfParticles.setDim((int(dimensions[0]), int(dimensions[1]), 1))
 
+        # Getting input element list according to data type
+        inputList = inputSubtomograms.iterSubtomos() if isinstance(inputSubtomograms, SetOfSubTomograms) else inputSubtomograms
+        inputList = [subtomogram if isinstance(subtomogram, SubTomogram) else subtomogram.getFileName() for subtomogram in inputList]
+
         # Adding projections of each subtomogram as a particle each
-        for subtomogram in inputSubtomograms.iterItems():
+        for subtomogram in inputList:
             readSetOfParticles(self.getProjectionMetadataAbsolutePath(subtomogram), outputSetOfParticles)
 
         # Defining the ouput with summary and source relation

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -356,7 +356,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
             
         return baseErrorStr + error if error else ''
 
-
     # --------------------------- UTILS functions --------------------------------------------
     def scapePath(self, path: str) -> str:
         """

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -77,6 +77,8 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         form.addSection(label='Input subtomograms')
         form.addParam('inputSubtomograms', params.PointerParam, pointerClass="SetOfSubTomograms,SetOfVolumes",
                       label='Set of subtomograms', help="Set of subtomograms whose projections will be generated.")
+        form.addParam('hasCtfCorrected', params.BooleanParam, default='True', label='Is CTF corrected?: ',
+                        help='Set this option to True if the input set of subtomograms has no CTF or the CTF has been corrected.')
         form.addParam('cleanTmps', params.BooleanParam, default='True', label='Clean temporary files: ', expertLevel=params.LEVEL_ADVANCED,
                         help='Clean temporary files after finishing the execution.\nThis is useful to reduce unnecessary disk usage.')
         form.addParam('transformMethod', params.EnumParam, display=params.EnumParam.DISPLAY_COMBO, default=self.METHOD_FOURIER,
@@ -118,8 +120,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         """
         This function writes the config file for Xmipp Phantom.
         """
-        confFile = open(self.getXmippParamPath(), "w")
-
         # Generating file content
         content = '# XMIPP_STAR_1 *\n'
         content += '# Projection Parameters\n'
@@ -140,6 +140,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         content += '# Noise\n'
 
         # Writing content to file and closing
+        confFile = open(self.getXmippParamPath(), "w")
         confFile.write(content)
         confFile.close()
 

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -191,11 +191,11 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         errors = []
 
         # Checking if number of samples is greater or equal than 1
-        if self.tiltTypeGeneration.get() == self.TYPE_N_SAMPLES and (not self.tiltRangeNSamples.get() == None) and self.tiltRangeNSamples.get() < 1:
+        if self.tiltTypeGeneration.get() == self.TYPE_N_SAMPLES and (self.tiltRangeNSamples.get() != None) and self.tiltRangeNSamples.get() < 1:
             errors.append('The number of samples cannot be less than 1.')
         
         # Checking if the step is greater than 0
-        if self.tiltTypeGeneration.get() == self.TYPE_STEP and (not self.tiltRangeStep.get() == None) and self.tiltRangeStep.get() <= 0:
+        if self.tiltTypeGeneration.get() == self.TYPE_STEP and (self.tiltRangeStep.get() != None) and self.tiltRangeStep.get() <= 0:
             errors.append('The step must be greater than 0.')
         
         # Checking if MPI is selected (only threads are allowed)

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -164,37 +164,18 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
             # If type of generation is not from Tilt Series, generate single param file
             paramDeps.append(self._insertFunctionStep(self.generateParamFile))
         
-        # Test:
-        idDict = {}
-        for subtomogram in self.inputSubtomograms.get():
-            if isinstance(subtomogram, SubTomogram):
-                if subtomogram.getCoordinate3D() and subtomogram.getCoordinate3D().getTomoId():
-                    if subtomogram.getCoordinate3D().getTomoId() not in idDict.keys():
-                        idDict[subtomogram.getCoordinate3D().getTomoId()] = 1
-                    else:
-                        idDict[subtomogram.getCoordinate3D().getTomoId()] += 1
-                else:
-                    if not subtomogram.getCoordinate3D():
-                        print("SKIPPED SUBTOMOGRAM. Does not have Coordinate 3D.", subtomogram.getFileName())
-                    else:
-                        print("SKIPPED SUBTOMOGRAM. Does not have tomo id.", subtomogram.getFileName())
-            else:
-                print("SKIPPED SUBTOMOGRAM. Not a Subtomogram.", subtomogram.getFileName())
-        
-        print("FULL DICT:", idDict)
-        
         # Generating projections for each subtomogram
-        #generationDeps = []
-        #for subtomogram in self.inputSubtomograms.get():
-        #    tsId = '' if self.tiltTypeGeneration.get() != self.TYPE_TILT_SERIES or len([ts for ts in self.tiltRangeTS.get()]) == 1 else subtomogram.getCoordinate3D().getTomoId()
-        #    generationDeps.append(self._insertFunctionStep(self.generateSubtomogramProjections, subtomogram.getFileName(), tsId, prerequisites=paramDeps))
-        #
-        ## Conditionally removing temporary files
-        #if self.cleanTmps.get():
-        #    self._insertFunctionStep(self.removeTempFiles, prerequisites=generationDeps)
-        #
-        ## Create output
-        #self._insertFunctionStep(self.createOutputStep, prerequisites=generationDeps)
+        generationDeps = []
+        for subtomogram in self.inputSubtomograms.get():
+            tsId = '' if self.tiltTypeGeneration.get() != self.TYPE_TILT_SERIES or len([ts for ts in self.tiltRangeTS.get()]) == 1 else subtomogram.getCoordinate3D().getTomoId()
+            generationDeps.append(self._insertFunctionStep(self.generateSubtomogramProjections, subtomogram.getFileName(), tsId, prerequisites=paramDeps))
+        
+        # Conditionally removing temporary files
+        if self.cleanTmps.get():
+            self._insertFunctionStep(self.removeTempFiles, prerequisites=generationDeps)
+        
+        # Create output
+        self._insertFunctionStep(self.createOutputStep, prerequisites=generationDeps)
 
     # --------------------------- STEPS functions --------------------------------------------
     def generateParamFile(self, tsId: str=''):

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -228,6 +228,9 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         self._defineOutputs(outputSetOfParticles=outputSetOfParticles)
         self._defineSourceRelation(self.inputSubtomograms, outputSetOfParticles)
 
+        # Test acquisition in particle
+        print("TEST PARTICLE:", outputSetOfParticles.getFirstItem().getAcquisition())
+
     # --------------------------- INFO functions --------------------------------------------
     def _validate(self):
         """

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -116,10 +116,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         
         # Tilt related parameter group
         tiltGroup = form.addGroup('Tilt parameters')
-        tiltLine = tiltGroup.addLine("Tilt range (degrees)", help='The initial and final values of the range of angles the projection will be produced on.\n'
-                            'Defaults to -60º for initial and 60º for final.')
-        tiltLine.addParam('tiltRangeStart', params.IntParam, default=-60, label='Start: ')
-        tiltLine.addParam('tiltRangeEnd', params.IntParam, default=60, label='End: ')
         tiltGroup.addParam('tiltTypeGeneration', params.EnumParam, display=params.EnumParam.DISPLAY_COMBO, default=self.TYPE_N_SAMPLES,
                         choices=['NSamples', 'Step', 'Tilt Series'], label="Type of sample generation: ",
                         help='Select the method for generating samples:\n\n'
@@ -132,6 +128,10 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
                         help='Number of degrees each sample will be separated from the next.\nIt has to be greater than 0.')
         tiltGroup.addParam('tiltRangeTS', params.PointerParam, pointerClass="SetOfTiltSeries",  condition=f'tiltTypeGeneration=={self.TYPE_TILT_SERIES}',
                            label='Set of Tilt Series:', help='Set of Tilt Series where the angles of each Tilt Series will be obtained for the projection.')
+        tiltLine = tiltGroup.addLine("Tilt range (degrees)", condition=f'tiltTypeGeneration!={self.TYPE_TILT_SERIES}',
+                        help='The initial and final values of the range of angles the projection will be produced on.\nDefaults to -60º for initial and 60º for final.')
+        tiltLine.addParam('tiltRangeStart', params.IntParam, default=-60, label='Start: ')
+        tiltLine.addParam('tiltRangeEnd', params.IntParam, default=60, label='End: ')
 
     # --------------------------- INSERT steps functions --------------------------------------------
     def _insertAllSteps(self):

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -317,7 +317,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         except TypeError:
             errorMessage = " ".join(["No subtomograms were received. Check the output of the previous protocol.",
                                      "If you are using the integrated test, run the extract subtomos's test first."])
-            raise Exception(errorMessage)
+            raise TypeError(errorMessage)
 
     def getXmippParamPath(self):
         """

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -40,7 +40,7 @@ from pyworkflow.protocol import params
 
 # External plugin imports
 from tomo.protocols import ProtTomoBase
-from tomo.objects import SubTomogram, Coordinate3D, TiltSeries
+from tomo.objects import SubTomogram, Coordinate3D, TiltSeries, TomoAcquisition
 from xmipp3.convert import readSetOfParticles
 
 # Protocol output variable name
@@ -181,6 +181,15 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         outputSetOfParticles.setAlignmentProj()
         dimensions = self.getSubtomogramDimensions().split(' ')
         outputSetOfParticles.setDim((int(dimensions[0]), int(dimensions[1]), 1))
+
+        # Setting acquisition info
+        #from tomo.objects import SetOfSubTomograms
+        acquisition = TomoAcquisition()
+        print("TEST first item", inputSubtomograms.getFirstItem())
+        print("TEST first acquisition", inputSubtomograms.getFirstItem().getAcquisition())
+        print("TEST acquisition", inputSubtomograms.getAcquisition())
+        acquisition.copyInfo(inputSubtomograms.getAcquisition())
+        outputSetOfParticles.setAcquisition(acquisition)
 
         # Getting input element list
         inputList = [subtomogram.getFileName() for subtomogram in inputSubtomograms]

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -31,7 +31,7 @@ import os
 
 # Scipion em imports
 from pwem.protocols import EMProtocol
-from pwem.objects import SetOfParticles
+from pwem.objects import SetOfParticles, CTFModel
 from pyworkflow import BETA
 from pyworkflow.protocol import params
 
@@ -182,7 +182,14 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         # Adding projections of each subtomogram as a particle each
         for subtomogram in inputList:
             readSetOfParticles(self.getProjectionMetadataAbsolutePath(subtomogram), outputSetOfParticles)
-
+        
+        # Setting CTF for every output particle
+        if self.hasCtfCorrected:
+            for particle in outputSetOfParticles.iterItems():
+                ctfModel = CTFModel(defocusU=0.0, defocusV=0.0, defocusAngle=0.0, phaseShift=0.0)
+                ctfModel._defocusRatio.set(1.0)
+                particle.setCTF(ctfModel)
+        
         # Defining the ouput with summary and source relation
         outputSetOfParticles.setObjComment(self.getSummary(outputSetOfParticles))
         self._defineOutputs(outputSetOfParticles=outputSetOfParticles)

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -146,7 +146,11 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
 
         # Generating projections for each subtomogram
         for subtomogram in self.inputSubtomograms.get():
-            deps.append(self._insertFunctionStep(self.generateSubtomogramProjections, subtomogram.getFileName(), useparamFile=useParamFile, prerequisites=deps))
+            generationDeps = []
+            generationDeps.append(self._insertFunctionStep(self.generateSubtomogramProjections, subtomogram.getFileName(), useparamFile=useParamFile, prerequisites=deps))
+        
+        # Updating dependency list
+        deps = deps + generationDeps
 
         # Conditionally removing temporary files
         if self.cleanTmps.get():

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -183,11 +183,7 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         outputSetOfParticles.setDim((int(dimensions[0]), int(dimensions[1]), 1))
 
         # Setting acquisition info
-        #from tomo.objects import SetOfSubTomograms
         acquisition = TomoAcquisition()
-        print("TEST first item", inputSubtomograms.getFirstItem())
-        print("TEST first acquisition", inputSubtomograms.getFirstItem().getAcquisition())
-        print("TEST acquisition", inputSubtomograms.getAcquisition())
         acquisition.copyInfo(inputSubtomograms.getAcquisition())
         outputSetOfParticles.setAcquisition(acquisition)
 
@@ -227,9 +223,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         outputSetOfParticles.setObjComment(self.getSummary(outputSetOfParticles))
         self._defineOutputs(outputSetOfParticles=outputSetOfParticles)
         self._defineSourceRelation(self.inputSubtomograms, outputSetOfParticles)
-
-        # Test acquisition in particle
-        print("TEST PARTICLE:", outputSetOfParticles.getFirstItem().getAcquisition())
 
     # --------------------------- INFO functions --------------------------------------------
     def _validate(self):

--- a/xmipptomo/protocols/protocol_project_subtomograms.py
+++ b/xmipptomo/protocols/protocol_project_subtomograms.py
@@ -141,7 +141,6 @@ class XmippProtProjectSubtomograms(EMProtocol, ProtTomoBase):
         if self.tiltTypeGeneration.get() == self.TYPE_TILT_SERIES:
             # Obtaining list of angle tilts and rots per Tilt Series
             angles = self.getAngleDictionary()
-            #print("DICTIONARY:", angles)
 
             # Generating a metadata angle file and a param file for each Tilt Series
             for tsId in angles:

--- a/xmipptomo/utils.py
+++ b/xmipptomo/utils.py
@@ -27,27 +27,27 @@
 This module contains utils functions for xmipp tomo protocols
 """
 
+# General imports
 import math
 import csv
 import os
 
+# Scipion em imports
 import emtable
-from tomo.constants import BOTTOM_LEFT_CORNER
-import numpy as np
+from pwem import ALIGN_PROJ
+from pwem.objects import Integer, CTFModel
 from pwem.emlib import lib
 import pwem.emlib.metadata as md
 from pwem.emlib.image import ImageHandler
 import pyworkflow as pw
-from pyworkflow.object import Set
-from tomo.objects import MATRIX_CONVERSION, convertMatrix, TiltSeries, TiltImage
-from pwem import ALIGN_PROJ
+
+# External plugin imports
+from tomo.objects import TiltSeries, TiltImage, SetOfCTFTomoSeries
+from tomo.constants import BOTTOM_LEFT_CORNER
 from xmipp3.convert import alignmentToRow
 
 OUTPUT_TILTSERIES_NAME = "TiltSeries"
 OUTPUT_TS_INTERPOLATED_NAME = "InterpolatedTiltSeries"
-
-from pwem.objects import Transform
-
 
 def calculateRotationAngleAndShiftsFromTM(ti):
     """ This method calculates que tilt image rotation angle from its associated transformation matrix."""
@@ -204,3 +204,12 @@ def writeMdTiltSeries(ts, tomoPath, fnXmd=None):
 
     return fnts
 
+def getCTFfromId(setOfCTFs: SetOfCTFTomoSeries, targetTsId: Integer) -> CTFModel:
+    """
+    This function returns the CTF from the set with the given target Tilt series id. 
+    """
+    # Iterate CTF set looking for the one with targetTsId
+    for ctf in setOfCTFs:
+        # If ctf id matches target TS id, return such CTF
+        if targetTsId == ctf.getTsId():
+            return ctf


### PR DESCRIPTION
- Now, projection angles can be extracted from a Tilt Series (only allowed for sets of subtomograms that come from a Tilt Series in the same workflow)
- Some error control
- Better calculated CTF in some cases