### PR TITLE
Fixed Score coordinates and phantom subtomo tests

### DIFF
--- a/xmipptomo/__init__.py
+++ b/xmipptomo/__init__.py
@@ -39,7 +39,7 @@ class Plugin(xmipp3.Plugin):
     @classmethod
     def getTensorFlowEnviron(cls):
         """ Create the needed environment for XmippTomo programs. """
-        environ = pwutils.Environ(os.environ)
+        environ = xmipp3.Plugin.getEnviron()
         environ.update({
             "TF_FORCE_GPU_ALLOW_GROWTH": "'true'"
         }, position=pwutils.Environ.BEGIN)

--- a/xmipptomo/protocols/protocol_score_coordinates.py
+++ b/xmipptomo/protocols/protocol_score_coordinates.py
@@ -158,12 +158,12 @@ class XmippProtScoreCoordinates(ProtTomoPicking):
                         newCoord.outlierScore = Float(scoreCoordOutlier)
                         outSet.append(newCoord)
                 elif not self.outliers.get() and self.carbon.get():
-                    if self.carbonThreshold.get() <= scoreCoordCarbon:
+                    if scoreCoordCarbon <= self.carbonThreshold.get():
                         newCoord.carbonScore = Float(scoreCoordCarbon)
                         outSet.append(newCoord)
                 elif self.outliers.get() and self.carbon.get():
                     if self.outliersThreshold.get() >= scoreCoordOutlier and \
-                       self.carbonThreshold.get() <= scoreCoordCarbon:
+                       scoreCoordCarbon <= self.carbonThreshold.get():
                         newCoord.outlierScore = Float(scoreCoordOutlier)
                         newCoord.carbonScore = Float(scoreCoordCarbon)
                         outSet.append(newCoord)

--- a/xmipptomo/tests/test_protocol_phantom_subtomo.py
+++ b/xmipptomo/tests/test_protocol_phantom_subtomo.py
@@ -24,6 +24,7 @@
 # *
 # **************************************************************************
 
+from pwem.protocols import ProtImportPdb
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from xmipp3.protocols import XmippProtConvertPdb
 
@@ -39,13 +40,16 @@ class TestXmippSubtomoPhantom(BaseTest):
         cls.pdb = cls.dataset.getFile('pdb')
         setupTestProject(cls)
 
+        pdbid = "3j3i"
+        cls.protImport = cls._importAtomicModel(ProtImportPdb, pdbid)
+
         setSize = True
         sizeX = 128
         sizeY = 128
         sizeZ = 128
-        pdbid = "3j3i"
+        pdbObj = cls.protImport.outputPdb
         sampling = 1
-        cls.protConvert = cls._runVolumeFromPDB(XmippProtConvertPdb, pdbid, sampling, setSize, sizeZ, sizeY, sizeX)
+        cls.protConvert = cls._runVolumeFromPDB(XmippProtConvertPdb, pdbObj, sampling, setSize, sizeZ, sizeY, sizeX)
 
 
         inputVolume = cls.protConvert.outputVolume
@@ -87,10 +91,17 @@ class TestXmippSubtomoPhantom(BaseTest):
                                 applyShift, xmin, xmax, ymin, ymax, zmin, zmax, coords, addNoise, differentStatistics, minstd, maxStd)
 
     @classmethod
-    def _runVolumeFromPDB(cls, protocolName, pdbid, sampling, setSize, size_z, size_y, size_x):
+    def _importAtomicModel(cls, protocolName, pdbid):
 
+        print("Import an atomic model from database")
+        cls.protImport = cls.newProtocol(protocolName, pdbId=pdbid)
+        cls.launchProtocol(cls.protImport)
+        return cls.protImport
+
+    @classmethod
+    def _runVolumeFromPDB(cls, protocolName, pdbid, sampling, setSize, size_z, size_y, size_x):
         print("Run convert a pdb from database")
-        cls.protConvert = cls.newProtocol(protocolName, pdbId=pdbid, sampling=sampling, setSize=setSize,
+        cls.protConvert = cls.newProtocol(protocolName, pdbObj=pdbid, sampling=sampling, setSize=setSize,
                                        size_z=size_z, size_y=size_y, size_x=size_x)
         cls.launchProtocol(cls.protConvert)
         return cls.protConvert

--- a/xmipptomo/tests/test_protocols_xmipptomo.py
+++ b/xmipptomo/tests/test_protocols_xmipptomo.py
@@ -296,9 +296,10 @@ class XmippTomoScoreCoordinates(BaseTest):
 
     def _createProtScoreCarbon(self, protCoords):
         protScoreCoordinates = self.newProtocol(XmippProtScoreCoordinates,
-                                                objLabel='Filter Carbon - Threshold 0.8',
+                                                objLabel='Filter Carbon - Threshold 0.85',
                                                 inputCoordinates=protCoords.outputCoordinates,
                                                 filter=1,
+                                                carbonThreshold=0.85,
                                                 outliers=False)
         self.launchProtocol(protScoreCoordinates)
         return getattr(protScoreCoordinates, 'outputCoordinates')

--- a/xmipptomo/tests/test_protocols_xmipptomo.py
+++ b/xmipptomo/tests/test_protocols_xmipptomo.py
@@ -286,7 +286,7 @@ class XmippTomoScoreCoordinates(BaseTest):
                                                    filesPath=self.dataset.getPath(),
                                                    importTomograms=protImportTomogram.Tomograms,
                                                    filesPattern='*.txt', boxSize=32,
-                                                   samplingRate=5)
+                                                   samplingRate=2)
         self.launchProtocol(protImportCoordinates3d)
         output = getattr(protImportCoordinates3d, 'outputCoordinates', None)
         self.assertIsNotNone(output,
@@ -322,7 +322,7 @@ class XmippTomoScoreCoordinates(BaseTest):
         #                 "There was a problem with score coordinates output")
         self.assertTrue(filteredCoords.getSize() == 5)
         self.assertTrue(filteredCoords.getBoxSize() == 32)
-        self.assertTrue(filteredCoords.getSamplingRate() == 5)
+        self.assertTrue(filteredCoords.getSamplingRate() == 2)
 
         # Test Outlier based filtering
         filteredCoords = self._createProtScoreOutliers(protCoords)
@@ -330,7 +330,7 @@ class XmippTomoScoreCoordinates(BaseTest):
         #                 "There was a problem with score coordinates output")
         self.assertTrue(filteredCoords.getSize() == 0)
         self.assertTrue(filteredCoords.getBoxSize() == 32)
-        self.assertTrue(filteredCoords.getSamplingRate() == 5)
+        self.assertTrue(filteredCoords.getSamplingRate() == 2)
 
 
 class TestXmipptomoHalfMaps(BaseTest):


### PR DESCRIPTION
Some checks to be done:

- Check if score coordinate test is robust enough or extra changes are needed

- Check micrograph cleaner scores (good particles should have a score closer to 0 or 1?)

- Check if phantom subtomo tests runs fins (locally I am getting an error when doing a `--fourier wedge` filter with Xmipp, but it might be a local installation problem).